### PR TITLE
✅ test(munit): cover all HTTP status codes simulated by the http-status API

### DIFF
--- a/src/test/munit/http-status-all-test-suite.xml
+++ b/src/test/munit/http-status-all-test-suite.xml
@@ -16,138 +16,1310 @@
 
   <!-- Exercises the http-status API for EVERY status code it can simulate.
        Uses the existing global HTTP_Request_configuration (localhost:8081),
-       which matches the port of HTTP_Listener_config used by http-status-main. -->
+       which matches the port of HTTP_Listener_config used by http-status-main.
+       One dedicated munit:test per status code, no foreach. -->
 
-  <!-- 1) All statuses simulated in a single test: a permissive response validator
-         (200..599) lets the requester accept every status without raising errors,
-         so we can assert the returned statusCode and body for each one. -->
+  <!-- ============================= -->
+  <!-- 1) All 19 codes simulated: a permissive response validator (200..599)
+         lets the requester accept every status without raising errors, so we
+         can assert the returned statusCode and body for each one. -->
+  <!-- ============================= -->
+
   <munit:test
-    name="http-status-all-codes-simulated-Test"
+    name="http-status-simulated-200-Test"
     timeOut="900000">
     <munit:enable-flow-sources>
       <munit:enable-flow-source
         value="http-status-main" />
     </munit:enable-flow-sources>
     <munit:execution>
-      <set-variable
-        doc:name="expectedStatuses"
-        variableName="expectedStatuses"
-        value="#[[200, 201, 204, 209, 400, 401, 403, 404, 405, 409, 410, 415, 422, 429, 500, 502, 503, 504, 511]]" />
-      <set-variable
-        doc:name="results"
-        variableName="results"
-        value="#[[]]" />
-      <foreach
-        doc:name="For Each expected status"
-        collection="#[vars.expectedStatuses]">
-        <set-variable
-          doc:name="expectedStatus"
-          variableName="expectedStatus"
-          value="#[payload]" />
-        <http:request
-          config-ref="HTTP_Request_configuration"
-          method="GET"
-          doc:name="GET /api/http-status/{httpStatus}"
-          path="#['/api/http-status/' ++ (vars.expectedStatus as String)]">
-          <http:response-validator>
-            <http:success-status-code-validator
-              values="200..599" />
-          </http:response-validator>
-        </http:request>
-        <set-variable
-          doc:name="results + { expected, actual, bodyCode }"
-          variableName="results"
-          value="#[vars.results + { expected: vars.expectedStatus, actual: attributes.statusCode, bodyCode: if (vars.expectedStatus == 204) vars.expectedStatus else payload.code }]" />
-      </foreach>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/200"
+        path="/api/http-status/200">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
     </munit:execution>
     <munit:validation>
       <munit-tools:assert-that
-        doc:name="Every status code was returned as requested"
-        expression="#[vars.results filter ($.expected != $.actual)]"
-        is="#[MunitTools::equalTo([])]"
-        message="#['Some statuses were not simulated as expected: ' ++ write(vars.results, 'application/json')]" />
+        doc:name="Status code is 200"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(200)]" />
       <munit-tools:assert-that
-        doc:name="Every JSON body echoes the simulated code"
-        expression="#[vars.results filter ($.expected != $.bodyCode)]"
-        is="#[MunitTools::equalTo([])]"
-        message="#['Some bodies did not echo the simulated code: ' ++ write(vars.results, 'application/json')]" />
-      <munit-tools:assert-that
-        doc:name="All 19 statuses were exercised"
-        expression="#[sizeOf(vars.results)]"
-        is="#[MunitTools::equalTo(19)]" />
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(200)]" />
     </munit:validation>
   </munit:test>
 
-  <!-- 2) Error statuses through the DEFAULT response validator: each 4xx/5xx
-         raises a real Mule error (HTTP:BAD_REQUEST, HTTP:NOT_FOUND, ...) that a
-         consumer of this API would have to handle. -->
   <munit:test
-    name="http-status-error-codes-raise-errors-Test"
+    name="http-status-simulated-201-Test"
     timeOut="900000">
     <munit:enable-flow-sources>
       <munit:enable-flow-source
         value="http-status-main" />
     </munit:enable-flow-sources>
     <munit:execution>
-      <set-variable
-        doc:name="errorStatuses"
-        variableName="errorStatuses"
-        value="#[[400, 401, 403, 404, 405, 409, 410, 415, 422, 429, 500, 502, 503, 504, 511]]" />
-      <set-variable
-        doc:name="results"
-        variableName="results"
-        value="#[[]]" />
-      <foreach
-        doc:name="For Each error status"
-        collection="#[vars.errorStatuses]">
-        <set-variable
-          doc:name="expectedStatus"
-          variableName="expectedStatus"
-          value="#[payload]" />
-        <try doc:name="Try">
-          <http:request
-            config-ref="HTTP_Request_configuration"
-            method="GET"
-            doc:name="GET /api/http-status/{httpStatus}"
-            path="#['/api/http-status/' ++ (vars.expectedStatus as String)]" />
-          <!-- Reaching this line means NO error was raised: record it so validation fails. -->
-          <set-variable
-            doc:name="results + { errorType: null }"
-            variableName="results"
-            value="#[vars.results + { expected: vars.expectedStatus, actual: attributes.statusCode, errorType: null }]" />
-          <error-handler>
-            <on-error-continue
-              enableNotifications="false"
-              logException="false"
-              doc:name="Capture simulated HTTP error">
-              <logger
-                level="INFO"
-                doc:name="Log simulated error"
-                message="#[output application/json --- { expected: vars.expectedStatus, statusCode: error.errorMessage.attributes.statusCode, errorType: (error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '') }]" />
-              <set-variable
-                doc:name="results + { expected, actual, errorType }"
-                variableName="results"
-                value="#[vars.results + { expected: vars.expectedStatus, actual: error.errorMessage.attributes.statusCode, errorType: (error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '') }]" />
-            </on-error-continue>
-          </error-handler>
-        </try>
-      </foreach>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/201"
+        path="/api/http-status/201">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
     </munit:execution>
     <munit:validation>
       <munit-tools:assert-that
-        doc:name="Every error status came back as requested"
-        expression="#[vars.results filter ($.expected != $.actual)]"
-        is="#[MunitTools::equalTo([])]"
-        message="#['Some statuses were not simulated as expected: ' ++ write(vars.results, 'application/json')]" />
+        doc:name="Status code is 201"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(201)]" />
       <munit-tools:assert-that
-        doc:name="Every error status raised a Mule error"
-        expression="#[vars.results filter ($.errorType == null)]"
-        is="#[MunitTools::equalTo([])]"
-        message="#['Some statuses did NOT raise an error: ' ++ write(vars.results, 'application/json')]" />
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(201)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-204-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/204"
+        path="/api/http-status/204">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
       <munit-tools:assert-that
-        doc:name="All 15 error statuses were exercised"
-        expression="#[sizeOf(vars.results)]"
-        is="#[MunitTools::equalTo(15)]" />
+        doc:name="Status code is 204"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(204)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-209-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/209"
+        path="/api/http-status/209">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 209"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(209)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(209)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-400-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/400"
+        path="/api/http-status/400">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 400"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(400)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(400)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-401-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/401"
+        path="/api/http-status/401">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 401"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(401)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(401)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-403-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/403"
+        path="/api/http-status/403">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 403"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(403)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(403)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-404-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/404"
+        path="/api/http-status/404">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 404"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(404)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(404)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-405-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/405"
+        path="/api/http-status/405">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 405"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(405)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(405)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-409-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/409"
+        path="/api/http-status/409">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 409"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(409)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(409)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-410-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/410"
+        path="/api/http-status/410">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 410"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(410)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(410)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-415-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/415"
+        path="/api/http-status/415">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 415"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(415)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(415)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-422-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/422"
+        path="/api/http-status/422">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 422"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(422)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(422)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-429-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/429"
+        path="/api/http-status/429">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 429"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(429)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(429)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-500-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/500"
+        path="/api/http-status/500">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 500"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(500)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(500)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-502-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/502"
+        path="/api/http-status/502">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 502"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(502)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(502)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-503-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/503"
+        path="/api/http-status/503">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 503"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(503)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(503)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-504-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/504"
+        path="/api/http-status/504">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 504"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(504)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(504)]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-simulated-511-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request
+        config-ref="HTTP_Request_configuration"
+        method="GET"
+        doc:name="GET /api/http-status/511"
+        path="/api/http-status/511">
+        <http:response-validator>
+          <http:success-status-code-validator
+            values="200..599" />
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Status code is 511"
+        expression="#[attributes.statusCode]"
+        is="#[MunitTools::equalTo(511)]" />
+      <munit-tools:assert-that
+        doc:name="Body echoes the simulated code"
+        expression="#[payload.code]"
+        is="#[MunitTools::equalTo(511)]" />
+    </munit:validation>
+  </munit:test>
+
+  <!-- ============================= -->
+  <!-- 2) The 15 error statuses again through the DEFAULT response validator:
+         each 4xx/5xx raises a real Mule error (HTTP:BAD_REQUEST, HTTP:NOT_FOUND, ...)
+         that a consumer of this API would have to handle. The error handler captures
+         the status code and error type into variables, since `error` isn't reachable
+         from munit:validation. -->
+  <!-- ============================= -->
+
+  <munit:test
+    name="http-status-raises-error-400-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/400"
+          path="/api/http-status/400" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 400, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 400"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(400)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-401-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/401"
+          path="/api/http-status/401" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 401, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 401"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(401)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-403-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/403"
+          path="/api/http-status/403" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 403, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 403"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(403)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-404-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/404"
+          path="/api/http-status/404" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 404, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 404"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(404)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-405-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/405"
+          path="/api/http-status/405" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 405, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 405"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(405)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-409-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/409"
+          path="/api/http-status/409" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 409, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 409"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(409)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-410-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/410"
+          path="/api/http-status/410" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 410, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 410"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(410)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-415-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/415"
+          path="/api/http-status/415" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 415, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 415"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(415)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-422-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/422"
+          path="/api/http-status/422" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 422, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 422"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(422)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-429-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/429"
+          path="/api/http-status/429" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 429, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 429"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(429)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-500-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/500"
+          path="/api/http-status/500" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 500, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 500"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(500)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-502-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/502"
+          path="/api/http-status/502" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 502, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 502"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(502)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-503-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/503"
+          path="/api/http-status/503" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 503, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 503"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(503)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-504-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/504"
+          path="/api/http-status/504" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 504, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 504"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(504)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
+    </munit:validation>
+  </munit:test>
+
+  <munit:test
+    name="http-status-raises-error-511-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <try doc:name="Try">
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/511"
+          path="/api/http-status/511" />
+        <error-handler>
+          <on-error-continue
+            enableNotifications="false"
+            logException="false"
+            doc:name="Capture simulated HTTP error">
+            <set-variable
+              doc:name="capturedStatusCode"
+              variableName="capturedStatusCode"
+              value="#[error.errorMessage.attributes.statusCode]" />
+            <set-variable
+              doc:name="capturedErrorType"
+              variableName="capturedErrorType"
+              value="#[(error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '')]" />
+            <logger
+              level="INFO"
+              doc:name="Log simulated error"
+              message="#[output application/json --- { expected: 511, statusCode: vars.capturedStatusCode, errorType: vars.capturedErrorType }]" />
+          </on-error-continue>
+        </error-handler>
+      </try>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Error raised with statusCode 511"
+        expression="#[vars.capturedStatusCode]"
+        is="#[MunitTools::equalTo(511)]" />
+      <munit-tools:assert-that
+        doc:name="Error type was captured"
+        expression="#[vars.capturedErrorType]"
+        is="#[MunitTools::notNullValue()]" />
     </munit:validation>
   </munit:test>
 

--- a/src/test/munit/http-status-all-test-suite.xml
+++ b/src/test/munit/http-status-all-test-suite.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule
+  xmlns:http="http://www.mulesoft.org/schema/mule/http"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+  xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+  xmlns="http://www.mulesoft.org/schema/mule/core"
+  xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+  xsi:schemaLocation="
+    http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+    http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+    http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+    http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+  <munit:config name="http-status-all-test-suite.xml" />
+
+  <!-- Exercises the http-status API for EVERY status code it can simulate.
+       Uses the existing global HTTP_Request_configuration (localhost:8081),
+       which matches the port of HTTP_Listener_config used by http-status-main. -->
+
+  <!-- 1) All statuses simulated in a single test: a permissive response validator
+         (200..599) lets the requester accept every status without raising errors,
+         so we can assert the returned statusCode and body for each one. -->
+  <munit:test
+    name="http-status-all-codes-simulated-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <set-variable
+        doc:name="expectedStatuses"
+        variableName="expectedStatuses"
+        value="#[[200, 201, 204, 209, 400, 401, 403, 404, 405, 409, 410, 415, 422, 429, 500, 502, 503, 504, 511]]" />
+      <set-variable
+        doc:name="results"
+        variableName="results"
+        value="#[[]]" />
+      <foreach
+        doc:name="For Each expected status"
+        collection="#[vars.expectedStatuses]">
+        <set-variable
+          doc:name="expectedStatus"
+          variableName="expectedStatus"
+          value="#[payload]" />
+        <http:request
+          config-ref="HTTP_Request_configuration"
+          method="GET"
+          doc:name="GET /api/http-status/{httpStatus}"
+          path="#['/api/http-status/' ++ (vars.expectedStatus as String)]">
+          <http:response-validator>
+            <http:success-status-code-validator
+              values="200..599" />
+          </http:response-validator>
+        </http:request>
+        <set-variable
+          doc:name="results + { expected, actual, bodyCode }"
+          variableName="results"
+          value="#[vars.results + { expected: vars.expectedStatus, actual: attributes.statusCode, bodyCode: if (vars.expectedStatus == 204) vars.expectedStatus else payload.code }]" />
+      </foreach>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Every status code was returned as requested"
+        expression="#[vars.results filter ($.expected != $.actual)]"
+        is="#[MunitTools::equalTo([])]"
+        message="#['Some statuses were not simulated as expected: ' ++ write(vars.results, 'application/json')]" />
+      <munit-tools:assert-that
+        doc:name="Every JSON body echoes the simulated code"
+        expression="#[vars.results filter ($.expected != $.bodyCode)]"
+        is="#[MunitTools::equalTo([])]"
+        message="#['Some bodies did not echo the simulated code: ' ++ write(vars.results, 'application/json')]" />
+      <munit-tools:assert-that
+        doc:name="All 19 statuses were exercised"
+        expression="#[sizeOf(vars.results)]"
+        is="#[MunitTools::equalTo(19)]" />
+    </munit:validation>
+  </munit:test>
+
+  <!-- 2) Error statuses through the DEFAULT response validator: each 4xx/5xx
+         raises a real Mule error (HTTP:BAD_REQUEST, HTTP:NOT_FOUND, ...) that a
+         consumer of this API would have to handle. -->
+  <munit:test
+    name="http-status-error-codes-raise-errors-Test"
+    timeOut="900000">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source
+        value="http-status-main" />
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <set-variable
+        doc:name="errorStatuses"
+        variableName="errorStatuses"
+        value="#[[400, 401, 403, 404, 405, 409, 410, 415, 422, 429, 500, 502, 503, 504, 511]]" />
+      <set-variable
+        doc:name="results"
+        variableName="results"
+        value="#[[]]" />
+      <foreach
+        doc:name="For Each error status"
+        collection="#[vars.errorStatuses]">
+        <set-variable
+          doc:name="expectedStatus"
+          variableName="expectedStatus"
+          value="#[payload]" />
+        <try doc:name="Try">
+          <http:request
+            config-ref="HTTP_Request_configuration"
+            method="GET"
+            doc:name="GET /api/http-status/{httpStatus}"
+            path="#['/api/http-status/' ++ (vars.expectedStatus as String)]" />
+          <!-- Reaching this line means NO error was raised: record it so validation fails. -->
+          <set-variable
+            doc:name="results + { errorType: null }"
+            variableName="results"
+            value="#[vars.results + { expected: vars.expectedStatus, actual: attributes.statusCode, errorType: null }]" />
+          <error-handler>
+            <on-error-continue
+              enableNotifications="false"
+              logException="false"
+              doc:name="Capture simulated HTTP error">
+              <logger
+                level="INFO"
+                doc:name="Log simulated error"
+                message="#[output application/json --- { expected: vars.expectedStatus, statusCode: error.errorMessage.attributes.statusCode, errorType: (error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '') }]" />
+              <set-variable
+                doc:name="results + { expected, actual, errorType }"
+                variableName="results"
+                value="#[vars.results + { expected: vars.expectedStatus, actual: error.errorMessage.attributes.statusCode, errorType: (error.errorType.namespace default '') ++ ':' ++ (error.errorType.identifier default '') }]" />
+            </on-error-continue>
+          </error-handler>
+        </try>
+      </foreach>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that
+        doc:name="Every error status came back as requested"
+        expression="#[vars.results filter ($.expected != $.actual)]"
+        is="#[MunitTools::equalTo([])]"
+        message="#['Some statuses were not simulated as expected: ' ++ write(vars.results, 'application/json')]" />
+      <munit-tools:assert-that
+        doc:name="Every error status raised a Mule error"
+        expression="#[vars.results filter ($.errorType == null)]"
+        is="#[MunitTools::equalTo([])]"
+        message="#['Some statuses did NOT raise an error: ' ++ write(vars.results, 'application/json')]" />
+      <munit-tools:assert-that
+        doc:name="All 15 error statuses were exercised"
+        expression="#[sizeOf(vars.results)]"
+        is="#[MunitTools::equalTo(15)]" />
+    </munit:validation>
+  </munit:test>
+
+</mule>


### PR DESCRIPTION
## Summary

Adds the first MUnit test suite to this repo (`src/test/munit/http-status-all-test-suite.xml` — the folder previously only contained `.gitkeep`), so that **every HTTP status code the http-status API can simulate is covered in MUnit**.

The tests enable the `http-status-main` flow source (APIKit router + listener on port 8081) and call the real API through the existing global `HTTP_Request_configuration`.

## What it covers

- **All 19 codes** (`200, 201, 204, 209, 400, 401, 403, 404, 405, 409, 410, 415, 422, 429, 500, 502, 503, 504, 511`) via `GET /api/http-status/{httpStatus}` using a permissive `200..599` response validator, asserting:
  - the returned `attributes.statusCode` equals the requested code, and
  - the JSON body echoes the code (`payload.code`), except for `204 No Content`.
- **The 15 error codes** again through the **default** response validator, asserting each one raises a real Mule error (`error.errorMessage.attributes.statusCode` matches) and logging the raised `error.errorType` for visibility.

## Verification

- XML well-formedness validated with `xmllint`.
- ⚠️ `mvn test` could not be executed in this sandbox: the network policy blocks `repository.mulesoft.org` and `maven.anypoint.mulesoft.com`, so the Mule runtime/MUnit artifacts cannot be downloaded (also, only Java 21 is available here while `app.runtime` is 4.6.9). Please run `mvn clean test` locally to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHWtYyqVEVFwgk58e6eo77

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHWtYyqVEVFwgk58e6eo77)_